### PR TITLE
fix: code style inconsistency

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,7 @@
+// custom SCSS (or CSS) goes here
+pre
+{
+    -moz-tab-size: 4;
+    -o-tab-size:   4;
+    tab-size:      4;
+}

--- a/runtime/go/usage.md
+++ b/runtime/go/usage.md
@@ -16,7 +16,7 @@ as well.
 
 ```go
 import (
-    "github.com/refraction-networking/water"
+	"github.com/refraction-networking/water"
 	_ "github.com/refraction-networking/water/transport/v0" // import the v0 transport module spec
 )
 ```

--- a/transport-module/go/watm.md
+++ b/transport-module/go/watm.md
@@ -20,49 +20,6 @@ Currently, `watm` is still under active development and supports only TinyGo as 
 
 The `tinygo/v0` package provides a set of helper functions to build WATM with spec version 0 from WebAssembly-agnostic Go code. It is designed to be used with TinyGo.
 
-<!-- TODO: Add documentations to API Reference? -->
-<details>
-  <summary>API Reference</summary>
-
-```go
-type RelayWrapSelection bool
-
-const (
-    RelayWrapRemote RelayWrapSelection = false
-    RelayWrapSource RelayWrapSelection = true
-)
-
-type ConfigurableTransport interface {
-    Configure([]byte) error
-}
-
-type DialingTransport interface {
-    SetDialer(dialer func(network, address string) (v0net.Conn, error))
-    Dial(network, address string) (v0net.Conn, error)
-}
-
-
-type ListeningTransport interface {
-    SetListener(listener v0net.Listener)
-    Accept() (v0net.Conn, error)
-}
-
-type WrappingTransport interface {
-    Wrap(v0net.Conn) (v0net.Conn, error)
-}
-
-func BuildDialerWithDialingTransport(DialingTransport)
-func BuildDialerWithWrappingTransport(WrappingTransport)
-
-func BuildListenerWithListeningTransport(ListeningTransport)
-func BuildListenerWithWrappingTransport(WrappingTransport)
-
-func BuildRelayWithListeningDialingTransport(ListeningTransport, DialingTransport)
-func BuildRelayWithWrappingTransport(WrappingTransport, RelayWrapSelection)
-```
-
-</details>
-
 ### `tinygo/v0/net` package 
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/refraction-networking/watm.svg)](https://pkg.go.dev/github.com/refraction-networking/watm/tinygo/v0/net)

--- a/transport-module/spec.md
+++ b/transport-module/spec.md
@@ -46,9 +46,11 @@ To help developers understand the API, we provide the following representations 
 
 <details>
     <summary>Imports</summary>
-    
-```go
-//go:wasmimport env host_dial
+
+<div class="highlighter-rouge">
+<div class="highlight">
+<pre class="highlight">
+<code>//go:wasmimport env host_dial
 //go:noescape
 func _import_host_dial() (fd int32)
 
@@ -62,15 +64,19 @@ func _import_pull_config() (fd int32)
 
 //go:wasmimport env host_defer
 //go:noescape
-func _import_host_defer()
-```
+func _import_host_defer()</code>
+</pre>
+</div>
+</div>
 </details>
 
 <details>
     <summary>Exports</summary>
 
-```go
-//export _water_v0
+<div class="highlighter-rouge">
+<div class="highlight">
+<pre class="highlight">
+<code>//export _water_v0
 func _water_v0()
 
 //export _water_init
@@ -89,8 +95,10 @@ func _water_accept(internalFd int32) (networkFd int32)
 func _water_associate() int32
 
 //export _water_worker
-func _water_worker() int32
-```
+func _water_worker() int32</code>
+</pre>
+</div>
+</div>
 </details>
 
 ### Rust representation
@@ -104,8 +112,10 @@ _Note that the following is a simplified example and may not strictly follow the
 <details>
   <summary>Imports</summary>
 
-```wit
-// imports.wit
+<div class="highlighter-rouge">
+<div class="highlight">
+<pre class="highlight">
+<code>// imports.wit
 package env;
 
 interface host {
@@ -117,14 +127,19 @@ interface host {
 
 world host-world {
     import host;
-}
-```
+}</code>
+</pre>
+</div>
+</div>
 </details>
 
 <details>
   <summary>Exports</summary>
 
-```wit
+<div class="highlighter-rouge">
+<div class="highlight">
+<pre class="highlight">
+<code>
 // exports.wit
 interface wasm {
     _water_v0: func(); // version 0 identifier
@@ -138,6 +153,8 @@ interface wasm {
 
 world wasm-world {
     export wasm;
-}
-```
+}</code>
+</pre>
+</div>
+</div>
 </details>


### PR DESCRIPTION
- Fix a problem causing code collapsible not rendering code in spec.md.
- Update tab width to be equal to 4 from 8 in custom.css.
- Fix a tab-space mix up problem in usage.md.
- Removed redundant API spec in watm.md where all the content can be found on go.dev.